### PR TITLE
Fix problem of lack of 'nm' in root

### DIFF
--- a/wfapi/node.py
+++ b/wfapi/node.py
@@ -53,7 +53,7 @@ class Node():
 
     @property
     def name(self):
-        return self.raw['nm']
+        return self.raw.get('nm')
 
     @property
     def description(self):
@@ -176,7 +176,7 @@ class Node():
 
 class WeakNode(Node):
     __slots__ = []
-    
+
     # virtual attribute
     _wf = NotImplemented
     # _project?


### PR DESCRIPTION
>>> import wfapi
>>> wf = wfapi.Workflowy(username='jastrzab5+wf@gmail.com', password='****')
>>> wf.pretty_print()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/havk/.virtualenvs/wfcli/src/wfapi/wfapi/workflowy.py", line 278, in pretty_print
    self.main.pretty_print()
  File "/home/havk/.virtualenvs/wfcli/src/wfapi/wfapi/node.py", line 154, in pretty_print
    is_empty_root = self.projectid == DEFAULT_ROOT_NODE_ID and not self.name and indent == 0
  File "/home/havk/.virtualenvs/wfcli/src/wfapi/wfapi/node.py", line 56, in name
    return self.raw['nm']
KeyError: 'nm'
